### PR TITLE
Added iOS 13 inside version number

### DIFF
--- a/LegacyComponents/LegacyComponentsInternal.m
+++ b/LegacyComponents/LegacyComponentsInternal.m
@@ -75,6 +75,9 @@ int iosMajorVersion()
             case 12:
                 version = 12;
                 break;
+            case 13:
+                version = 13;
+                break;
             default:
                 version = 9;
                 break;


### PR DESCRIPTION
If there is no special reasons why iOS 13 is missing inside `iosMajorVersion` function, would be good to include in nearest release, because default value is **9** and a lot of things related to safe area is broken on iOS 13.