### PR TITLE
A.rychkov/contest fixes

### DIFF
--- a/LegacyComponents/TGModernConversationInputMicButton.m
+++ b/LegacyComponents/TGModernConversationInputMicButton.m
@@ -231,8 +231,12 @@ static const CGFloat outerCircleMinScale = innerCircleRadius / outerCircleRadius
         return;
     }
     UIView *parentView = [_presentation view];
-    
-    CGPoint centerPoint = [self.superview convertPoint:self.center toView:parentView];
+
+    // Self and parent view may be in different windows
+    CGPoint centerPointInSelfWindow = [self.window convertPoint:self.center fromView:self.superview];
+    CGPoint centerPointInParentViewWindow = [self.window convertPoint:centerPointInSelfWindow toWindow:parentView.window];
+    CGPoint centerPoint = [parentView.window convertPoint:centerPointInParentViewWindow toView:parentView];
+
     centerPoint.x += _centerOffset.x;
     centerPoint.y += _centerOffset.y;
     _innerCircleView.center = centerPoint;

--- a/LegacyComponents/TGPhotoPaintController.m
+++ b/LegacyComponents/TGPhotoPaintController.m
@@ -360,6 +360,9 @@ const CGFloat TGPhotoPaintStickerKeyboardSize = 260.0f;
     [_landscapeToolsWrapperView addSubview:_landscapeSettingsView];
     
     [self setCurrentSwatch:_portraitSettingsView.swatch sender:nil];
+
+    if (![self _updateControllerInset:false])
+        [self controllerInsetUpdated:UIEdgeInsetsZero];
 }
 
 - (void)setupCanvas

--- a/LegacyComponents/TGVideoCameraGLRenderer.m
+++ b/LegacyComponents/TGVideoCameraGLRenderer.m
@@ -155,7 +155,30 @@
                 _textureVertices[7] = 0.0f;
             }
             break;
-            
+        case AVCaptureVideoOrientationPortraitUpsideDown:
+            if (!_mirror)
+            {
+                _textureVertices[0] = 1.0f - centerOffset;
+                _textureVertices[1] = 0.0f;
+                _textureVertices[2] = 1.0f - centerOffset;
+                _textureVertices[3] = 1.0f;
+                _textureVertices[4] = centerOffset;
+                _textureVertices[5] = 0.0f;
+                _textureVertices[6] = centerOffset;
+                _textureVertices[7] = 1.0f;
+            }
+            else
+            {
+                _textureVertices[0] = centerOffset;
+                _textureVertices[1] = 1.0f;
+                _textureVertices[2] = centerOffset;
+                _textureVertices[3] = 0.0f;
+                _textureVertices[4] = 1.0f - centerOffset;
+                _textureVertices[5] = 1.0f;
+                _textureVertices[6] = 1.0f - centerOffset;
+                _textureVertices[7] = 0.0f;
+            }
+            break;
         default:
             break;
     }

--- a/LegacyComponents/TGVideoMessageCaptureController.m
+++ b/LegacyComponents/TGVideoMessageCaptureController.m
@@ -535,10 +535,16 @@ typedef enum
                 
             break;
     }
+
+    if (TGIsPad()) {
+        _circleWrapperView.center = targetPosition;
+    }
     
     [UIView animateWithDuration:0.5 delay:0.0 usingSpringWithDamping:0.8f initialSpringVelocity:0.2f options:kNilOptions animations:^
     {
-        _circleWrapperView.center = targetPosition;
+        if (!TGIsPad()) {
+            _circleWrapperView.center = targetPosition;
+        }
         _circleWrapperView.transform = CGAffineTransformIdentity;
     } completion:nil];
     

--- a/LegacyComponents/TGVideoMessageCaptureController.m
+++ b/LegacyComponents/TGVideoMessageCaptureController.m
@@ -322,9 +322,7 @@ typedef enum
     [_circleWrapperView addSubview:_ringView];
     
     CGRect controlsFrame = _controlsFrame;
-    CGFloat height = TGIsPad() ? 56.0f : 45.0f;
-    controlsFrame.origin.y = CGRectGetMaxY(controlsFrame) - height;
-    controlsFrame.size.height = height;
+    controlsFrame.size.width = _wrapperView.frame.size.width;
     
     _controlsView = [[TGVideoMessageControls alloc] initWithFrame:controlsFrame assets:_assets];
     _controlsView.pallete = self.pallete;
@@ -369,7 +367,7 @@ typedef enum
     };
     [self.view addSubview:_controlsView];
     
-    _separatorView = [[UIView alloc] initWithFrame:CGRectMake(_controlsView.frame.origin.x, _controlsFrame.origin.y - TGScreenPixel, _controlsView.frame.size.width, TGScreenPixel)];
+    _separatorView = [[UIView alloc] initWithFrame:CGRectMake(controlsFrame.origin.x, controlsFrame.origin.y - TGScreenPixel, controlsFrame.size.width, TGScreenPixel)];
     _separatorView.backgroundColor = self.pallete != nil ? self.pallete.borderColor : UIColorRGB(0xb2b2b2);
     _separatorView.userInteractionEnabled = false;
     [self.view addSubview:_separatorView];

--- a/LegacyComponents/TGVideoMessageCaptureController.m
+++ b/LegacyComponents/TGVideoMessageCaptureController.m
@@ -279,8 +279,14 @@ typedef enum
         _fadeView.backgroundColor = [curtainColor colorWithAlphaComponent:0.6f];
         [_wrapperView addSubview:_fadeView];
     }
-    
-    _circleWrapperView = [[UIView alloc] initWithFrame:CGRectMake((_wrapperView.frame.size.width - 216.0f - 38.0f) / 2.0f, _wrapperView.frame.size.height + 100.0f, 216.0f + 38.0f, 216.0f + 38.0f)];
+
+    CGFloat circleWrapperViewLength = 216.0f + 38.0f;
+    _circleWrapperView = [[UIView alloc] initWithFrame:(CGRect){
+        .origin.x = (_wrapperView.bounds.size.width - circleWrapperViewLength) / 2.0f,
+        .origin.y = _wrapperView.bounds.size.height + circleWrapperViewLength * 0.3f,
+        .size.width = circleWrapperViewLength,
+        .size.height = circleWrapperViewLength
+    }];
     _circleWrapperView.alpha = 0.0f;
     _circleWrapperView.clipsToBounds = false;
     [_wrapperView addSubview:_circleWrapperView];
@@ -304,8 +310,14 @@ typedef enum
         _shadowView.accessibilityIgnoresInvertColors = true;
         _placeholderView.accessibilityIgnoresInvertColors = true;
     }
-    
-    _ringView = [[TGVideoMessageRingView alloc] initWithFrame:CGRectMake((_circleWrapperView.frame.size.width - 234.0f) / 2.0f, (_circleWrapperView.frame.size.height - 234.0f) / 2.0f, 234.0f, 234.0f)];
+
+    CGFloat ringViewLength = 234.0f;
+    _ringView = [[TGVideoMessageRingView alloc] initWithFrame:(CGRect){
+        .origin.x = (_circleWrapperView.bounds.size.width - ringViewLength) / 2.0f,
+        .origin.y = (_circleWrapperView.bounds.size.height - ringViewLength) / 2.0f,
+        .size.width = ringViewLength,
+        .size.height = ringViewLength
+    }];
     _ringView.accentColor = self.pallete != nil ? self.pallete.buttonColor : TGAccentColor();
     [_circleWrapperView addSubview:_ringView];
     
@@ -508,19 +520,15 @@ typedef enum
     
     _circleWrapperView.transform = CGAffineTransformMakeScale(0.3f, 0.3f);
     
-    CGPoint targetPosition = CGPointMake(_wrapperView.frame.size.width / 2.0f, _wrapperView.frame.size.height / 2.0f - _controlsView.frame.size.height);
+    CGPoint targetPosition = (CGPoint){
+        .x = _wrapperView.frame.size.width / 2.0f,
+        .y = _wrapperView.frame.size.height / 2.0f - _controlsView.frame.size.height
+    };
     switch (self.interfaceOrientation)
     {
         case UIInterfaceOrientationLandscapeLeft:
-            targetPosition.x = MIN(_wrapperView.frame.size.width - _circleWrapperView.bounds.size.width / 2.0f - 20.0f, _wrapperView.frame.size.width / 4.0f * 3.0f);
-            targetPosition.y = self.view.frame.size.height / 2.0f;
-            break;
-            
         case UIInterfaceOrientationLandscapeRight:
-            targetPosition.x = MAX(_circleWrapperView.bounds.size.width / 2.0f + 20.0f, _wrapperView.frame.size.width / 4.0f);
-            targetPosition.y = self.view.frame.size.height / 2.0f;
             break;
-            
         default:
             if (self.view.frame.size.height > self.view.frame.size.width && fabs(_wrapperView.frame.size.height - self.view.frame.size.height) < 50.0f)
                 targetPosition.y = _wrapperView.frame.size.height / 3.0f - 20.0f;

--- a/LegacyComponents/TGVideoMessageControls.m
+++ b/LegacyComponents/TGVideoMessageControls.m
@@ -341,7 +341,7 @@ static CGRect viewFrame(UIView *view)
 {
     UIImage *deleteImage = _assets.actionDelete;
     
-    _deleteButton = [[TGModernButton alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 45.0f, 45.0f)];
+    _deleteButton = [[TGModernButton alloc] initWithFrame:CGRectMake(0.0f, (self.bounds.size.height - 45.0f) / 2.0f, 45.0f, 45.0f)];
     [_deleteButton setImage:deleteImage forState:UIControlStateNormal];
     _deleteButton.adjustsImageWhenDisabled = false;
     _deleteButton.adjustsImageWhenHighlighted = false;
@@ -491,7 +491,7 @@ static CGRect viewFrame(UIView *view)
     }
     
     setViewFrame(_sendButton, CGRectMake(self.frame.size.width - _sendButton.frame.size.width, 0.0f, _sendButton.frame.size.width, self.frame.size.height));
-    _deleteButton.center = CGPointMake(24.0f, 22.0f);
+    _deleteButton.center = CGPointMake(24.0f, self.bounds.size.height / 2.0f);
     setViewFrame(_scrubberView, CGRectMake(46.0f, (self.frame.size.height - 33.0f) / 2.0f, self.frame.size.width - 46.0f * 2.0f, 33.0f));
 }
 


### PR DESCRIPTION
1. Bug. Active audio message controls are misplaced or not shown at all on iPad in landscape or upside down mode.

Technical description: -[UIView convertFrame:toView:] doesn’t work for views in different hierarchies. I converted views’ frames to window they located in.

2. Bug. Video message recorder is partly visible on iPad in landscape mode.

Technical description: Video recorder layout is wrong for landscape orientation. I fixed the layout.

Remarks: I've decided to put recorder view in the center of the screen for consistency. As a variant, it can be placed closer to active record button. Feel free to contact me and discuss this decision.

3. Bug. Video message recorder controls have wrong layout on iPad in landscape mode.

Technical description: Controls' container height differs from input view height and some views' layout is not updated for iPad. I fixed the layout.

4. Improvement: video recorder appear animation distracts and messes around the screen on iPad cause of long movement distance.

Technical description: I removed movement animation on iPad. The recorder only animates its scale.

5. Bug. Video recorder doesn’t work at all in upside down orientation on iPad. It records white screen.

Technical description: OpenGL video renderer texture vertices have no values in UpsideDown orientation. I filled the vertices with correct texture coordinates.

6. Bug. User can’t interact with sticker selection header (the most important – can't tap cancel and close the screen) in photo editor screen opened from profile image upload. (Header is placed under the notch).

Technical description: Safe area is not set for the view. I set the safe area.